### PR TITLE
V1.5.21 - Namespaced Package Added (#362)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,6 @@
 sfdx-project.json
+node_modules/
+.sf/
+.sfdx/
+.husky/
+coverage/

--- a/Contributing.md
+++ b/Contributing.md
@@ -21,7 +21,7 @@ When submitting a pull request, please follow these guidelines:
 
 - there should be no errors when running `npm run scan` or `yarn scan`
 - ensure your dependencies have been installed and that any/all file(s) changed have had prettier-apex run on them (usually as simple as enabling "Format On Save" in your editor's options); alternatively you can always format the document in Vs Code using `Shift + Ctrl + F` or `cmd + Shift + F` once you're done writing. Your mileage may vary as to the hotkey if you're using Illuminated Cloud or another text editor; you always have the option of invoking prettier on the command-line
-- ensure that tests have been run against a scratch org with multi-currency enabled (you can look at `scripts/test.ps1` to see how the scratch org is created and the currency ISO codes are loaded).
+- ensure that tests have been run against a scratch org with multi-currency enabled (you can look at [`scripts/test.ps1`](https://github.com/jamessimone/apex-rollup/blob/main/scripts/test.ps1) to see how the scratch org is created and the currency ISO codes are loaded).
 - ensure that any change to production code comes with the addition of tests. It's possible that I will accept PRs where _only_ production-level code is changed, if an optimization is put in place -- but otherwise, try to write a failing test first!
 - if you are testing on a scratch org, `sfdx force:source:push` will fail due to the Rollup Nebula Logger Adapter plugin. You can either:
   - temporarily comment out that plugin within the `packageDirectories` list in `sfdx-project.json`

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ As well, don't miss [the Wiki](../../wiki), which includes more advanced informa
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008b0ObAAI">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008b0RpAAI">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008b0ObAAI">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008b0RpAAI">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>
@@ -27,7 +27,7 @@ As well, don't miss [the Wiki](../../wiki), which includes more advanced informa
 <br/>
 <br/>
 
-Don't miss the [links to install the Rollup plugins!](#rollup-plugins)
+Don't miss the [links to install the Rollup plugins!](#rollup-plugins). For a namespaced version of Apex Rollup, [check the installation links here](./rollup-namespaced/README.md).
 
 _Before proceeding further_, Apex Rollup ships with a custom hierarchy setting, `Rollup Settings`, which you will have to create an Org Wide Default entry for by going to:
 
@@ -126,6 +126,7 @@ Within the `Rollup__mdt` custom metadata type, add a new record with fields:
 - `Grandparent Relationship Field Path` (optional) - if [you are rolling up to a grandparent (or greater) parent object](#grandparent-or-greater-rollups), use this field to establish the full relationship name of the field, eg from Opportunity Line Items directly to an Account's Annual Revenue: `Opportunity.Account.AnnualRevenue` would be used here. The field name (after the last period) should match up with what is being used in `Rollup Field On Parent Object`. For caveats and more information on how to setup rollups looking to use this functionality, please refer to the linked section.
 - `One To Many Grandparent Fields` (optional, comma-separated text field) - used with Grandparent rollups when intermediate objects are actually junction (children) objects. When using this field, provide a comma-separated list that contains the junction object name and the field name that provides the lookup to the next record in your "grandparent" rollup. For example, if your starting object is an Account, and Contact is the junction object, your grandparent relationship field path could be `Contacts.Individual.Name` and your `One To Many Grandparent Fields` value would be `Contact.AccountId`. Two things to note: `Contacts` in the grandparent field path refers to the relationship name to the object named prior to the period in the One To Many Grandparent Fields, and the field API name is used after the period. You can perform multiple junction object "hops" by separating your values with commas: `Contact.AccountId, SomeOtherObject__c.SomeOtherField__c`
 - `Rollup To Ultimate Parent` (optional) - Check this box if you are rolling up to an Account, for example, and use the `Parent Account ID` field on accounts, _and_ want the rolled up value to only be used on the top-level account. Can be used with any hierarchy lookup or lookup back to the same object. Must be used in conjunction with `Ultimate Parent Lookup` (below), and _can_ be used in conjunction with `Grandparent Relationship Field Path` (if the hierarchical field you are rolling up to is not on the immediate parent object).
+- `(Should) Run Without Custom Setting Flag?` - (optional) - If every configured Rollup has this flag set to true, it's not necessary to use the `RollupSetting__c.IsEnabled__c` flag on the included Custom Setting (useful for managed package implementations)
 - `Split Concat Delimiter On Child Object?` (optional) - By default, CONCAT and CONCAT_DISTINCT operations will only apply the concat delimiter to the parent-level rollup field. Enable this field to also split the rollup item's values before concatenating to the parent.
 - `Ultimate Parent Lookup` (optional) - specify the API Name of the field on the `Parent Object` using the dropdown that contains the hierarchy relationship. On Account, for example, this would be `Parent Account ID`. Must be filled out if `Rollup To Ultimate Parent` is checked.
 - `Description` (optional) - note-taking field in the event you'd like to provide additional info to other admins/users about your configured rollup
@@ -193,6 +194,7 @@ These are the fields on the `Rollup Control` custom metadata type:
 - `Should Duplicate Rules Be Ignored` (defaults to false) - By default, duplicate rules are enforced on rollup updates. Set this to true to bypass duplicate rules for rollups.
 - `Should Run As` - a picklist dictating the preferred method for running rollup operations. Possible values are `Queueable`, `Batchable`, or `Synchronous Rollup`.
 - `Should Run Single Records Synchronously` - Apex Rollup typically uses the `Should Run As` picklist to determine the default execution context for rollups (which tends to be async). This checkbox deviates from that methodology by forcing single record updates to run sync (whenever possible), which helps with handling updates from datatables or other features using Lightning Data Service (LDS).
+- `Should Skip Resetting Parent Fields` (defaults to false) - for full recalculations and REFRESH-based child item updates, Apex Rollup by default assumes that for a parent record with no matching children, the parent-level field should be reset. If this checkbox is set to true, those parent records without results will simply be ignored, and will not be updated.
 - `Trigger Or Invocable Name` - If you are using custom Apex, a schedulable, or rolling up by way of the Invocable action and can't use the Apex Rollup lookup field. Use the pattern `trigger_fieldOnCalcItem_to_rollupFieldOnTarget_rollup` - for example: 'trigger_opportunity_stagename_to_account_name_rollup' (use lowercase on the field names). If there is a matching Rollup Limit record, those rules will be used. The first part of the string comes from how a rollup has been invoked - either by `trigger`, `invocable`, or `schedule`. A scheduled flow still uses `invocable`!
 
 </details>

--- a/extra-tests/classes/CustomMetadataDrivenTests.cls
+++ b/extra-tests/classes/CustomMetadataDrivenTests.cls
@@ -143,4 +143,31 @@ private class CustomMetadataDrivenTests {
     grandparentTwo = [SELECT AmountfromChildren__c FROM RollupGrandParent__c WHERE Id = :grandparentTwo.Id];
     System.assertEquals(child.NumberField__c, grandparentTwo.AmountfromChildren__c);
   }
+
+  @IsTest
+  static void rollupsSucceedDuringFutureMethods() {
+    // uses a combination of Rollup__mdt found in extra-tests/customMetadata AND extra-tests/triggers/RollupChildTrigger.trigger
+    RollupParent__c parent = [SELECT Id FROM RollupParent__c];
+
+    Test.startTest();
+    insertRollupChildrenAsync(parent.Id, 'a', 3);
+    Test.stopTest();
+
+    parent = [SELECT Id, TextField__c, NumberField__c FROM RollupParent__c];
+    System.assertEquals('a', parent.TextField__c);
+    System.assertEquals(3, parent.NumberField__c);
+  }
+
+  @Future
+  static void insertRollupChildrenAsync(Id parentId, String firstTextField, Integer firstNumberField) {
+    // uses FIRST with TextField__c as the Order By field, MAX for the NumberField__c
+    RollupChild__c childOne = new RollupChild__c(
+      Name = 'Child one',
+      TextField__c = firstTextField,
+      RollupParent__c = parentId,
+      NumberField__c = firstNumberField
+    );
+    RollupChild__c childTwo = new RollupChild__c(Name = 'Child two', TextField__c = 'b', RollupParent__c = parentId, NumberField__c = 2);
+    insert new List<RollupChild__c>{ childOne, childTwo };
+  }
 }

--- a/extra-tests/classes/RollupFullRecalcTests.cls
+++ b/extra-tests/classes/RollupFullRecalcTests.cls
@@ -453,6 +453,58 @@ private class RollupFullRecalcTests {
   }
 
   @IsTest
+  static void preventsParentRecordResetsWhenControlIsFlagged() {
+    Rollup.defaultControl = new RollupControl__mdt(MaxLookupRowsBeforeBatching__c = 2, ShouldSkipResettingParentFields__c = true);
+
+    Account acc = [SELECT Id FROM Account];
+    acc.AnnualRevenue = 75;
+    acc.NumberOfEmployees = 15;
+    update acc;
+
+    List<ContactPointAddress> cpas = new List<ContactPointAddress>{ new ContactPointAddress(PreferenceRank = 500, ParentId = acc.Id, Name = 'One') };
+    insert cpas;
+
+    List<Rollup__mdt> metadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        CalcItem__c = 'ContactPointAddress',
+        LookupObject__c = 'Account',
+        LookupFieldOnCalcItem__c = 'ParentId',
+        RollupOperation__c = 'SUM',
+        RollupFieldOnLookupObject__c = 'AnnualRevenue',
+        RollupFieldOnCalcItem__c = 'PreferenceRank',
+        LookupFieldOnLookupObject__c = 'Id',
+        CalcItemWhereClause__c = 'Name != \'One\''
+      ),
+      new Rollup__mdt(
+        CalcItem__c = 'ContactPointAddress',
+        LookupObject__c = 'Account',
+        LookupFieldOnCalcItem__c = 'ParentId',
+        RollupOperation__c = 'COUNT',
+        RollupFieldOnLookupObject__c = 'NumberOfEmployees',
+        RollupFieldOnCalcItem__c = 'Id',
+        LookupFieldOnLookupObject__c = 'Id',
+        CalcItemWhereClause__c = 'Name != \'One\''
+      ),
+      new Rollup__mdt(
+        CalcItem__c = 'ContactPointAddress',
+        LookupObject__c = 'Account',
+        LookupFieldOnCalcItem__c = 'ParentId',
+        RollupOperation__c = 'CONCAT',
+        RollupFieldOnLookupObject__c = 'Description',
+        RollupFieldOnCalcItem__c = 'Name',
+        LookupFieldOnLookupObject__c = 'Id'
+      )
+    };
+
+    Test.startTest();
+    Rollup.performBulkFullRecalc(metadata, Rollup.InvocationPoint.FROM_FULL_RECALC_LWC.name());
+    Test.stopTest();
+
+    Account updatedAccount = [SELECT AnnualRevenue, NumberOfEmployees FROM Account WHERE Id = :acc.Id];
+    System.assertEquals(acc, updatedAccount);
+  }
+
+  @IsTest
   static void doesNotUpdateParentRecordsWithoutUpdatesWhenRecordsExcludedByEvaluator() {
     RollupTestUtils.DMLMock mock = new RollupTestUtils.DMLMock();
     Rollup.DML = mock;
@@ -1916,8 +1968,8 @@ private class RollupFullRecalcTests {
 
   @IsTest
   static void shouldCacheRetrievedCalcItemsBetweenFullRecalcRuns() {
-    // since we can't have more than one batch chunk run in the tests, but we need to test logic in the execute method
-    // we'll call that method twice directly
+    // additionalCalcItemCount shortcuts a Database.countQuery() call in RollupAsyncProcessor
+    // which reduces the MaxNumberOfQueries__c needed below
     RollupAsyncProcessor.additionalCalcItemCount = 1;
     Rollup.defaultControl = new RollupControl__mdt(
       BatchChunkSize__c = 1,
@@ -1952,6 +2004,8 @@ private class RollupFullRecalcTests {
       null
     );
     fullRecalc.addOrderBys(new List<RollupOrderBy__mdt>(), ContactPointAddress.PreferenceRank);
+    // since we can't have more than one batch chunk run in the tests, but we need to test logic in the execute method
+    // we'll call that method twice directly
     fullRecalc.execute(null, new List<ContactPointAddress>{ cpas[0] });
     fullRecalc.execute(null, new List<ContactPointAddress>{ cpas[1] });
 

--- a/extra-tests/classes/RollupQueryBuilderTests.cls
+++ b/extra-tests/classes/RollupQueryBuilderTests.cls
@@ -148,4 +148,16 @@ private class RollupQueryBuilderTests {
 
     System.assertEquals(0, countAmount, 'Should make it here because query was formatted correctly');
   }
+
+  @IsTest
+  static void doesNotBlowUpOnDeeplyNestedConditionals() {
+    String bigWhere = '(((Type = \'Event\' AND Status != \'Completed\' AND IsArchived = true) AND WhoId = :recordIds) OR ((Type = \'Letter-Note\' AND Status != \'Completed\' AND IsArchived = true) AND WhoId = :recordIds) OR ((Type = \'Meeting\' AND Status != \'Completed\' AND IsArchived = true) AND WhoId = :recordIds) OR ((Type = \'Email\' AND Status != \'Completed\' AND IsArchived = true) AND WhoId = :recordIds) OR ((Type = \'Call\' AND Status != \'Completed\' AND IsArchived = true) AND WhoId = :recordIds) OR ((Type = \'Text\' AND Status = \'Completed\' AND IsArchived = true) AND WhoId = :recordIds) OR ((Type = \'Voicemail\' AND Status = \'Completed\' AND IsArchived = true) AND WhoId = :recordIds) OR ((Type = \'Letter-Note\' AND Status = \'Completed\' AND IsArchived = true) AND WhoId = :recordIds) OR ((Type = \'Event\' AND Status = \'Completed\' AND IsArchived = true) AND WhoId = :recordIds) OR ((Type = \'Meeting\' AND Status = \'Completed\' AND IsArchived = true) AND WhoId = :recordIds) OR ((Type = \'Email\' AND Status = \'Completed\' AND IsArchived = true) AND WhoId = :recordIds) OR ((Type = \'Call\' AND Status = \'Completed\' AND IsArchived = true) AND WhoId = :recordIds))';
+
+    String queryString = RollupQueryBuilder.Current.getQuery(Task.SObjectType, new List<String>{ 'Id' }, 'Id', '=', bigWhere);
+
+    Set<Id> recordIds = new Set<Id>();
+    List<Task> tasks = Database.query(queryString);
+
+    System.assertEquals(true, tasks.isEmpty(), 'Should have made it here and query should have been run');
+  }
 }

--- a/extra-tests/classes/RollupTests.cls
+++ b/extra-tests/classes/RollupTests.cls
@@ -59,7 +59,7 @@ private class RollupTests {
   }
 
   @IsTest
-  static void shouldNotRunWhenDisabled() {
+  static void shouldNotRunWhenCustomSettingDisabled() {
     RollupSettings__c existingSetting = [SELECT Id, IsEnabled__c FROM RollupSettings__c];
     existingSetting.IsEnabled__c = false;
     update existingSetting;
@@ -72,6 +72,36 @@ private class RollupTests {
     Test.stopTest();
 
     System.assertEquals(true, mock.Records.isEmpty(), 'Records should not have been set or updated, custom setting was disabled');
+  }
+
+  @IsTest
+  static void ignoresCustomSettingWhenSpecificallyFlagged() {
+    RollupSettings__c existingSetting = [SELECT Id, IsEnabled__c FROM RollupSettings__c];
+    existingSetting.IsEnabled__c = false;
+    update existingSetting;
+
+    RollupTestUtils.DMLMock mock = RollupTestUtils.loadAccountIdMock(new List<ContactPointAddress>{ new ContactPointAddress(PreferenceRank = 50) });
+    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        RollupFieldOnCalcItem__c = 'PreferenceRank',
+        LookupObject__c = 'Account',
+        LookupFieldOnCalcItem__c = 'ParentId',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'AnnualRevenue',
+        RollupOperation__c = 'SUM',
+        CalcItem__c = 'ContactPointAddress',
+        ShouldRunWithoutCustomSettingEnabled__c = true
+      )
+    };
+
+    Test.startTest();
+    Rollup.runFromTrigger();
+    Test.stopTest();
+
+    System.assertNotEquals(true, mock.Records.isEmpty(), 'Account should have been updated');
+    Account acc = (Account) mock.Records[0];
+    System.assertEquals(50, acc.AnnualRevenue);
   }
 
   @IsTest

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.5.20",
+  "version": "1.5.21",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup-namespaced/README.md
+++ b/rollup-namespaced/README.md
@@ -1,0 +1,15 @@
+# Namespaced Version Of Apex Rollup
+
+This package contains the exact same source code as the unlocked Apex Rollup package; it's just created with a namespace. For more info, see the base `README`.
+
+## Deployment & Setup
+
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008b0RzAAI">
+  <img alt="Deploy to Salesforce"
+       src="./media/deploy-package-to-prod.png">
+</a>
+
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008b0RzAAI">
+  <img alt="Deploy to Salesforce Sandbox"
+       src="./media/deploy-package-to-sandbox.png">
+</a>

--- a/rollup-namespaced/sfdx-project.json
+++ b/rollup-namespaced/sfdx-project.json
@@ -1,0 +1,24 @@
+{
+    "packageDirectories": [
+        {
+            "default": true,
+            "package": "apex-rollup-namespaced",
+            "path": "rollup",
+            "versionName": "Added namespaced version of package, and override to always run rollups from Rollup__mdt",
+            "versionNumber": "1.0.0.0",
+            "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
+            "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest"
+        },
+        {
+            "path": "extra-tests",
+            "default": false
+        }
+    ],
+    "namespace": "please",
+    "sfdcLoginUrl": "https://login.salesforce.com",
+    "sourceApiVersion": "55.0",
+    "packageAliases": {
+        "apex-rollup-namespaced": "0Ho6g000000PBMjCAO",
+        "apex-rollup-namespaced@1.0.0-0": "04t6g000008b0RzAAI"
+    }
+}

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -1713,6 +1713,7 @@ global without sharing virtual class Rollup {
             RollupOperation__c,
             RollupToUltimateParent__c,
             SplitConcatDelimiterOnCalcItem__c,
+            ShouldRunWithoutCustomSettingEnabled__c,
             (SELECT Id, FieldName__c, NullSortOrder__c, Ranking__c, SortOrder__c FROM RollupOrderBys__r ORDER BY Ranking__c, DeveloperName)
           FROM Rollup__mdt
           WHERE RollupControl__r.ShouldAbortRun__c = FALSE

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -239,15 +239,20 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     // side effect in the below method - rollups can be removed from this.rollups if a control record ShouldAbortRun__c == true
     // they also can be added to syncRollups if we're already async
     List<RollupAsyncProcessor> syncRollups = new List<RollupAsyncProcessor>();
-    this.ingestRollupControlData(syncRollups);
+    Boolean shouldRunWithoutCustomSetting = this.ingestRollupControlData(syncRollups);
 
     if (this.isNoOp) {
       this.isNoOp = this.rollups.isEmpty() && syncRollups.isEmpty() && (this.isFullRecalc == false && this.calcItems?.isEmpty() == true);
     }
 
     String rollupProcessId = this.getNoProcessId();
-    if (this.isNoOp || this.rollupControl.ShouldAbortRun__c || RollupSettings__c.getInstance().IsEnabled__c == false) {
-      RollupLogger.Instance.log('no-op, exiting early to avoid burning async job', LoggingLevel.FINE);
+    String logMessage;
+    if (this.isNoOp) {
+      logMessage = 'no-op, exiting early to avoid burning async job';
+    } else if (this.rollupControl.ShouldAbortRun__c) {
+      logMessage = 'RollupControl__mdt.ShouldAbortRun__c set to true, exiting early';
+    } else if (RollupSettings__c.getInstance().IsEnabled__c == false && shouldRunWithoutCustomSetting == false) {
+      logMessage = 'RollupSettings__c.IsEnabled__c is false, exiting early';
     } else if (syncRollups.isEmpty() == false) {
       RollupLogger.Instance.log('about to process sync rollups', LoggingLevel.DEBUG);
       this.process(syncRollups);
@@ -259,6 +264,9 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
         (this.rollupControl.ShouldRunAs__c == RollupMetaPicklists.ShouldRunAs.Batchable &&
         totalCountOfRecords >= this.rollupControl.MaxLookupRowsBeforeBatching__c);
       rollupProcessId = this.getAsyncRollup()?.beginAsyncRollup();
+    }
+    if (logMessage != null) {
+      RollupLogger.Instance.log(logMessage, LoggingLevel.DEBUG);
     }
     RollupLogger.Instance.save();
     return rollupProcessId;
@@ -616,6 +624,10 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     return this.previouslyResetParents.contains(this.getParentResetKey(String.valueOf(processor.opFieldOnLookupObject), parent));
   }
 
+  protected virtual Boolean getCanRollupWithoutCustomSetting() {
+    return this.metadata?.ShouldRunWithoutCustomSettingEnabled__c == true;
+  }
+
   private Boolean getCanEnqueue() {
     return Limits.getLimitQueueableJobs() > Limits.getQueueableJobs();
   }
@@ -649,13 +661,11 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
   private void preProcessRollups(List<RollupAsyncProcessor> rollupsToProcess) {
     for (Integer index = rollupsToProcess.size() - 1; index >= 0; index--) {
       RollupAsyncProcessor rollup = rollupsToProcess[index];
-      List<RollupAsyncProcessor> additionalRollups = new List<RollupAsyncProcessor>();
+      List<RollupAsyncProcessor> additionalRollups = rollup.transformFullRecalcRollups();
       // this can be a conductor containing full recalc rollups
       if (rollup.rollups.isEmpty() == false) {
         this.preProcessRollups(rollup.rollups);
         additionalRollups.addAll(rollup.rollups);
-      } else {
-        additionalRollups = rollup.transformFullRecalcRollups();
       }
 
       if (additionalRollups.isEmpty() == false) {
@@ -884,10 +894,12 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     }
   }
 
-  private void ingestRollupControlData(List<RollupAsyncProcessor> syncRollups) {
+  private Boolean ingestRollupControlData(List<RollupAsyncProcessor> syncRollups) {
     Boolean isRunningAsnyc = this.getIsRunningAsync();
+    Boolean shouldRollupsRunWithoutCustomSetting = false;
     for (Integer index = this.rollups.size() - 1; index >= 0; index--) {
       RollupAsyncProcessor rollup = this.rollups[index];
+      shouldRollupsRunWithoutCustomSetting = rollup.getCanRollupWithoutCustomSetting();
       this.flagFullRecalcRollups(rollup);
 
       Boolean shouldRunSyncDeferred = this.getShouldRunSyncDeferred(rollup);
@@ -909,6 +921,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
 
       this.overrideParentRollupControlValues(rollup.rollupControl);
     }
+    return shouldRollupsRunWithoutCustomSetting;
   }
 
   private void flagFullRecalcRollups(RollupAsyncProcessor rollup) {
@@ -1045,7 +1058,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
           Object priorVal = lookupRecord.get(roll.opFieldOnLookupObject);
           Object priorValToUse = roll.isFullRecalc && this.parentRollupFieldHasBeenReset(roll, lookupRecord) == false ? null : priorVal;
           calc = this.getCalculator(calc, roll, localCalcItems, lookupRecord, priorValToUse, key, roll.lookupFieldOnCalcItem);
-          this.conditionallyPerformUpdate(priorVal, calc, lookupRecord, roll, recordsToUpdate, updater, 'lookup');
+          this.conditionallyPerformUpdate(priorVal, calc, lookupRecord, roll, recordsToUpdate, updater, 'lookup', localCalcItems);
         }
       }
     }
@@ -1104,7 +1117,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
   }
 
   private void handleFullRecalculators(RollupAsyncProcessor roll) {
-    if (roll instanceof RollupFullRecalcProcessor) {
+    if (roll instanceof RollupFullRecalcProcessor && roll.isProcessed == false) {
       this.deferredRollups.add(roll);
     }
   }
@@ -1176,7 +1189,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
         oldLookupsRollup.calcItems = reparentedCalcItems;
         RollupLogger.Instance.log('reparenting operation:', oldLookupsRollup, LoggingLevel.DEBUG);
         calc = this.getCalculator(calc, oldLookupsRollup, reparentedCalcItems, lookupRecord, priorVal, key, roll.lookupFieldOnCalcItem);
-        this.conditionallyPerformUpdate(priorVal, calc, lookupRecord, roll, recordsToUpdate, updater, 'reparented');
+        this.conditionallyPerformUpdate(priorVal, calc, lookupRecord, roll, recordsToUpdate, updater, 'reparented', reparentedCalcItems);
       }
     }
   }
@@ -1188,10 +1201,14 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     RollupAsyncProcessor roll,
     Map<String, SObject> recordsToUpdate,
     RollupSObjectUpdater updater,
-    String logKey
+    String logKey,
+    List<SObject> localCalcItems
   ) {
     RollupLogger.Instance.log(logKey + ' record prior to rolling up:', lookupRecord, LoggingLevel.DEBUG);
     Object newVal = calc.getReturnValue();
+    if (this.rollupControl.ShouldSkipResettingParentFields__c == true && ((localCalcItems.isEmpty() == false && newVal == null) || localCalcItems.isEmpty())) {
+      newVal = priorVal;
+    }
     if (priorVal != newVal) {
       String key = (String) lookupRecord.get(roll.lookupFieldOnLookupObject);
       RollupLogger.Instance.log('updating record ...', LoggingLevel.FINE);
@@ -1203,6 +1220,6 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
   }
 
   private Boolean getIsRunningAsync() {
-    return System.isBatch() || System.isQueueable() || System.isScheduled() || shouldFlattenAsyncProcesses == true;
+    return System.isBatch() || System.isQueueable() || System.isScheduled() || System.isFuture() || shouldFlattenAsyncProcesses == true;
   }
 }

--- a/rollup/core/classes/RollupEvaluator.cls
+++ b/rollup/core/classes/RollupEvaluator.cls
@@ -156,6 +156,8 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
     private final List<ConditionalGrouping> conditionalGroupings = new List<ConditionalGrouping>();
     private final Set<String> validRelationshipNames;
     private final Set<String> splitWheres = new Set<String>();
+    private final Set<String> previouslyParsedClauses = new Set<String>();
+
     private List<String> queryFields;
 
     public WhereFieldEvaluator(String whereClause, SObjectType calcItemSObjectType) {
@@ -360,6 +362,11 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
           }
           // we'll remove these blanks in a second
           localSplitWheres[originalMatchIndex] = '';
+
+          if (this.previouslyParsedClauses.contains(potentialNestedConditional)) {
+            continue;
+          }
+          this.previouslyParsedClauses.add(potentialNestedConditional);
 
           List<WhereFieldCondition> conditions = new List<WhereFieldCondition>();
           Boolean isAnInnerOrCondition = false;

--- a/rollup/core/classes/RollupFullRecalcProcessor.cls
+++ b/rollup/core/classes/RollupFullRecalcProcessor.cls
@@ -92,7 +92,7 @@ public abstract without sharing class RollupFullRecalcProcessor extends RollupAs
   }
 
   public void processParentFieldsToReset(List<SObject> relatedParentRecords) {
-    if (this.hasProcessedParentRecords) {
+    if (this.hasProcessedParentRecords || this.rollupControl.ShouldSkipResettingParentFields__c == true) {
       return;
     }
     this.hasProcessedParentRecords = true;
@@ -103,7 +103,7 @@ public abstract without sharing class RollupFullRecalcProcessor extends RollupAs
         : RollupCurrencyInfo.createNewRecord(parentRecordToReset);
 
       for (Rollup__mdt meta : this.rollupMetas) {
-        if (relatedParentRecord.getSobjectType().getDescribe().getName() == meta.LookupObject__c) {
+        if (relatedParentRecord.getSObjectType().getDescribe().getName() == meta.LookupObject__c) {
           relatedParentRecord.put(meta.RollupFieldOnLookupObject__c, null);
         }
       }
@@ -134,6 +134,18 @@ public abstract without sharing class RollupFullRecalcProcessor extends RollupAs
 
   protected override String getHashedContents() {
     return String.valueOf(this.rollupMetas);
+  }
+
+  protected override Boolean getCanRollupWithoutCustomSetting() {
+    Boolean canRollupWithoutCustomSetting = false;
+    for (Rollup__mdt rollupMeta : this.rollupMetas) {
+      canRollupWithoutCustomSetting = rollupMeta.ShouldRunWithoutCustomSettingEnabled__c == true;
+      // all included rollups need to have the override enabled; if even one does NOT, we can stop
+      if (canRollupWithoutCustomSetting == false) {
+        break;
+      }
+    }
+    return canRollupWithoutCustomSetting;
   }
 
   private void overrideRollupControl() {

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,7 +1,7 @@
 public without sharing virtual class RollupLogger implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.5.20';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.5.21';
   private static final LoggingLevel FALLBACK_LOGGING_LEVEL = LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
   private static Boolean disabledMessageHasBeenLogged = false;

--- a/rollup/core/classes/RollupParentResetProcessor.cls
+++ b/rollup/core/classes/RollupParentResetProcessor.cls
@@ -42,7 +42,7 @@ public without sharing class RollupParentResetProcessor extends RollupFullBatchR
     getRefinedQueryString(this.queryString, this.rollupMetas);
     this.objIds.addAll(this.recordIds);
     String processId = this.getNoProcessId();
-    if (isValidRun == false) {
+    if (isValidRun == false || this.rollupControl.ShouldSkipResettingParentFields__c == true) {
       return processId;
     }
     if (this.countOfItems == null) {

--- a/rollup/core/customMetadata/RollupControl.Org_Defaults.md-meta.xml
+++ b/rollup/core/customMetadata/RollupControl.Org_Defaults.md-meta.xml
@@ -59,6 +59,10 @@
         <value xsi:type="xsd:boolean">false</value>
     </values>
     <values>
+        <field>ShouldSkipResettingParentFields__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
         <field>TriggerOrInvocableName__c</field>
         <value xsi:nil="true" />
     </values>

--- a/rollup/core/objects/RollupControl__mdt/fields/ShouldSkipResettingParentFields__c.field-meta.xml
+++ b/rollup/core/objects/RollupControl__mdt/fields/ShouldSkipResettingParentFields__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>ShouldSkipResettingParentFields__c</fullName>
+    <defaultValue>false</defaultValue>
+    <description>If checked, Rollup won't reset parent record fields on full recalc/update</description>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <inlineHelpText>If checked, Rollup won't reset parent record fields on full recalc/update</inlineHelpText>
+    <label>Should Skip Resetting Parent Fields</label>
+    <type>Checkbox</type>
+</CustomField>

--- a/rollup/core/objects/Rollup__mdt/fields/ShouldRunWithoutCustomSettingEnabled__c.field-meta.xml
+++ b/rollup/core/objects/Rollup__mdt/fields/ShouldRunWithoutCustomSettingEnabled__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>ShouldRunWithoutCustomSettingEnabled__c</fullName>
+    <defaultValue>false</defaultValue>
+    <description>If true, configured rollup runs even if Custom Setting is not enabled</description>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <inlineHelpText>If true, configured rollup runs even if Custom Setting is not enabled</inlineHelpText>
+    <label>Runs Without Custom Setting Flag?</label>
+    <type>Checkbox</type>
+</CustomField>

--- a/scripts/build-and-promote-package.ps1
+++ b/scripts/build-and-promote-package.ps1
@@ -46,5 +46,5 @@ if ($currentBranch -eq "main") {
   Start-Package-Promotion
   Push-Git-Tag
 } else {
-  Generate -packageName "apex-rollup" -readmePath "./README.md"
+  Generate -packageName "apex-rollup" -readmePath "./README.md" -shouldCreateNamespacedPackage $true
 }

--- a/scripts/generatePackage.ps1
+++ b/scripts/generatePackage.ps1
@@ -74,6 +74,14 @@ function Update-Logger-Class {
   git add $loggerClassPath
 }
 
+function Update-SFDX-Project-JSON {
+  Write-Host "Re-writing sfdx-project.json  ..."
+  ConvertTo-Json -InputObject $sfdxProjectJson -Depth 4 | Set-Content -Path $sfdxProjectJsonPath -NoNewline
+  # sfdx-project.json is ignored by default; use another file as the --ignore-path to force prettier
+  # to run on it
+  npx prettier --write $sfdxProjectJsonPath --tab-width 4 --ignore-path ..\.forceignore
+}
+
 function Get-Next-Package-Version() {
   param ($currentPackage, $packageName)
   $currentPackageVersion = $currentPackage.versionNumber
@@ -87,11 +95,7 @@ function Get-Next-Package-Version() {
     $currentPackageVersion = $currentPackageVersion.Substring(0, $patchVersionIndex + 1) + $currentVersionNumber.ToString() + ".0"
     $currentPackage.versionNumber = $currentPackageVersion
 
-    Write-Host "Re-writing sfdx-project.json with updated package version number ..."
-    ConvertTo-Json -InputObject $sfdxProjectJson -Depth 4 | Set-Content -Path $sfdxProjectJsonPath -NoNewline
-    # sfdx-project.json is ignored by default; use another file as the --ignore-path to force prettier
-    # to run on it
-    npx prettier --write $sfdxProjectJsonPath --tab-width 4 --ignore-path ..\.forceignore
+    Update-SFDX-Project-JSON
   }
   if ("apex-rollup" -eq $packageName) {
     $versionNumberToWrite = $currentPackageVersion.Remove($currentPackageVersion.LastIndexOf(".0"))
@@ -107,11 +111,19 @@ function Get-Next-Package-Version() {
   }
 }
 
+function Get-Package-Directory() {
+  param (
+    [string]$packageName
+  )
+  return ($sfdxProjectJson.packageDirectories | Select-Object | Where-Object -Property package -eq $packageName)
+}
+
 # used in package.json scripts & build-and-promote-package.ps1
 function Generate() {
   param (
     [string]$packageName,
-    [string]$readmePath
+    [string]$readmePath,
+    [bool]$shouldCreateNamespacedPackage
   )
 
   Write-Host "Starting for $packageName" -ForegroundColor Yellow
@@ -120,25 +132,57 @@ function Generate() {
     Invoke-Extra-Code-Coverage-Prep
   }
 
-  $currentPackage = ($sfdxProjectJson.packageDirectories | Select-Object | Where-Object -Property package -eq $packageName)
+  $currentPackage = Get-Package-Directory $packageName
   Get-Next-Package-Version $currentPackage $packageName
   $currentPackageVersion = $currentPackage.versionNumber
-  $currentPackageName = $currentPackage.versionName
 
   Write-Host "Creating package version: $currentPackageVersion ..." -ForegroundColor White
 
-  $createPackageResult = npx sfdx force:package:version:create -p $packageName -w 30 -c -x -n $currentPackageVersion -a $currentPackageName --json | ConvertFrom-Json
+  $createPackageResult = npx sfdx force:package:version:create -p $packageName -w 30 -c -x -n $currentPackageVersion --json | ConvertFrom-Json
   $currentPackageVersionId = $createPackageResult.result.SubscriberPackageVersionId
   if ($null -eq $currentPackageVersionId) {
     throw $createPackageResult
   } else {
     npx sfdx bummer:package:aliases:sort
-    git add $sfdxProjectJsonPath
+    git add $sfdxProjectJsonPath -f
   }
 
   Write-Host "Successfully created package Id: $currentPackageVersionId" -ForegroundColor Green
 
   Update-Package-Install-Links $readmePath $currentPackageVersionId
 
-  Write-Host "Finished successfully!" -ForegroundColor Green
+  if ($shouldCreateNamespacedPackage -eq $true -and "apex-rollup" -eq $packageName) {
+    New-Namespaced-Package
+  }
+
+  Write-Host "Finished creating $packageName package version!" -ForegroundColor Green
+}
+
+function New-Namespaced-Package {
+  Write-Host "Generating namespaced version of package..." -ForegroundColor White
+
+  $namespacedPackageName = "apex-rollup-namespaced"
+  $namespacedProjectJsonPath = "rollup-namespaced/sfdx-project.json"
+  $originalProjectJsonBackupPath = "./sfdx-project-original.json"
+  $versionName = (Get-Package-Directory "apex-rollup").versionName
+
+  Copy-Item $sfdxProjectJsonPath $originalProjectJsonBackupPath -Force
+  Copy-Item $namespacedProjectJsonPath $sfdxProjectJsonPath -Force
+
+  # we always want to stay in lock-step with the current versionName between the non-namespace and namespaced versions of the package
+  $sfdxProjectJson = Get-SFDX-Project-JSON
+  $namespacedPackageDirectory = Get-Package-Directory $namespacedPackageName
+  $namespacedPackageDirectory.versionName = $versionName
+
+  Update-SFDX-Project-JSON
+
+  # now that the version name's been copied over, we're good to generate
+  Generate $namespacedPackageName "rollup-namespaced/README.md" $false
+
+  Copy-Item $sfdxProjectJsonPath $namespacedProjectJsonPath -Force
+  Copy-Item $originalProjectJsonBackupPath $sfdxProjectJsonPath -Force
+  Remove-Item $originalProjectJsonBackupPath
+
+  git add $sfdxProjectJsonPath -f
+  git add $namespacedProjectJsonPath -f
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "Swapped from Type.forName to Schema.describeSObjects where appropriate to save on speed, fixed issue where not all hierarchy rollups got CurrencyIsoCode correctly in multi-currency orgs, many optimizations.",
-            "versionNumber": "1.5.20.0",
+            "versionName": "Added namespaced version of package, and override to always run rollups from Rollup__mdt",
+            "versionNumber": "1.5.21.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {
@@ -103,6 +103,7 @@
         "apex-rollup@1.5.17-0": "04t6g000008SkuIAAS",
         "apex-rollup@1.5.18-0": "04t6g000008SkucAAC",
         "apex-rollup@1.5.19-0": "04t6g000008SkwxAAC",
-        "apex-rollup@1.5.20-0": "04t6g000008b0ObAAI"
+        "apex-rollup@1.5.20-0": "04t6g000008b0ObAAI",
+        "apex-rollup@1.5.21-0": "04t6g000008b0RpAAI"
     }
 }


### PR DESCRIPTION
* Doc updates which were missed as part of @jongpie feedback from `v1.5.20`
* Adds namespaced package version support for managed packages and unlocked packages with namespaces to be able to use Apex Rollup as per the discussion in #359
* Fixes #360 by adding Custom Setting override directly on Rollup__mdt
* Fixes issue reported by Kaushal Gautam where future methods weren't accounted for when considering when Apex Rollup was already async
* Fixes a bug reported by Katherine West where some full recalcs with many Calc Item Where Clauses had issues getting their where clauses parsed (potentially also reported by @solo-1234)
* Thanks to Kaushal Gautam (again!) for suggesting this new functionality: added ability to skip updating parents during full recalcs/full recalc updates when `RollupControl__mdt.ShouldSkipResettingParentFields__c` is set to true (defaults to false on the Org Default record)
* Added in clearer log messages when Apex Rollup is disabled:
  * `no-op, exiting early to avoid burning async job` when there are no configured rollups 
  * `RollupControl__mdt.ShouldAbortRun__c set to true, exiting early` when ... Should Abort Run on the given Rollup Control record is set to true
  * `RollupSettings__c.IsEnabled__c is false, exiting early` when the Rollup Settings Custom Setting isn't enabled _and_ the new override isn't enabled (see #360)